### PR TITLE
Remove logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,16 +45,6 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.7</version>
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>1.1.2</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
-        </dependency>
         <!-- TESTING -->
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Libraries should not include a slf4j backend.
It creates problems for those using the library - if they prefer a different backend, slf4j will complain that there are multiple implementations available.